### PR TITLE
Start description message with coverage number

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,9 @@ async function publishCheck(opts: { totals: { covered: number; total: number }; 
   const octokit = github.getOctokit(opts.token);
 
   const description = opts.totals.total
-    ? `Changed statement coverage ${((opts.totals.covered / opts.totals.total) * 100).toFixed(2)}%`
+    ? `${((opts.totals.covered / opts.totals.total) * 100).toFixed(
+        2
+      )}% of changed statements covered by tests`
     : `No changes`;
   const output = {
     owner: github.context.repo.owner,


### PR DESCRIPTION
GitHub truncates the description when it's too long to fit on a screen. To avoid the coverage number being truncated, put that first.

Before: Changed statement coverage  97.88%
After: 97.88% of changed statements covered by tests